### PR TITLE
Fix any_node updates after testing on robot.

### DIFF
--- a/hri_safety_sense/launch/hri_safety_sense_service.launch
+++ b/hri_safety_sense/launch/hri_safety_sense_service.launch
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?> 
+<?xml version="1.0" encoding="UTF-8"?>
 <launch>
-  <node name="hri_safety_sense" pkg="hri_safety_sense" type="safe_remote_control" output="log" launch-prefix="" respawn="true" >
+  <node name="hri_safety_sense" pkg="hri_safety_sense" type="safe_remote_control" output="log" launch-prefix="" respawn="false" >
     <rosparam file="$(find hri_safety_sense)/config/hri_safety_sense.yaml" command="load"/>
   </node>
 </launch>

--- a/hri_safety_sense/src/VscProcess.cpp
+++ b/hri_safety_sense/src/VscProcess.cpp
@@ -57,9 +57,9 @@ bool VscProcess::init() {
   /* Open VSC Interface */
   vscInterface = vsc_initialize(serialPort.c_str(),serialSpeed);
   if (vscInterface == NULL) {
-    ROS_FATAL("Cannot open serial port! (%s, %i)",serialPort.c_str(),serialSpeed);
+    ROS_INFO("Cannot open serial port! (%s, %i)",serialPort.c_str(),serialSpeed);
     return false;
-  } 
+  }
   ROS_INFO("Connected to VSC on %s : %i",serialPort.c_str(),serialSpeed);
 
   // Attempt to Set priority
@@ -71,10 +71,10 @@ bool VscProcess::init() {
 
   if(set_priority) {
     if(setpriority(PRIO_PROCESS, 0, -19) == -1) {
-      ROS_ERROR("UNABLE TO SET PRIORITY OF PROCESS! (%i, %s)",errno,strerror(errno));
-      return false;
+      ROS_INFO("UNABLE TO SET PRIORITY OF PROCESS! (%i, %s)",errno,strerror(errno));
     }
   }
+
   // Create Message Handlers
   joystickHandler = new JoystickHandler();
 
@@ -120,7 +120,12 @@ bool VscProcess::init() {
   // Clear all error counters
   memset(&errorCounts, 0, sizeof(errorCounts));
 
-  return addWorker(ros::this_node::getName() + "::updateWorker", 1.0/(double)VSC_INTERFACE_RATE, &VscProcess::update, this, 90);
+  bool success = addWorker(ros::this_node::getName() + "::updateWorker", 1.0/(double)VSC_INTERFACE_RATE, &VscProcess::update, this, 90);
+  if (!success) {
+    ROS_FATAL_STREAM("[hri] could not add worker! Update rate:" << 1.0/(double)VSC_INTERFACE_RATE);
+  }
+
+  return success;
 }
 
 void VscProcess::cleanup() {

--- a/hri_safety_sense/src/VscProcess.cpp
+++ b/hri_safety_sense/src/VscProcess.cpp
@@ -57,7 +57,7 @@ bool VscProcess::init() {
   /* Open VSC Interface */
   vscInterface = vsc_initialize(serialPort.c_str(),serialSpeed);
   if (vscInterface == NULL) {
-    ROS_INFO("Cannot open serial port! (%s, %i)",serialPort.c_str(),serialSpeed);
+    ROS_FATAL("Cannot open serial port! (%s, %i)",serialPort.c_str(),serialSpeed);
     return false;
   }
   ROS_INFO("Connected to VSC on %s : %i",serialPort.c_str(),serialSpeed);
@@ -71,7 +71,7 @@ bool VscProcess::init() {
 
   if(set_priority) {
     if(setpriority(PRIO_PROCESS, 0, -19) == -1) {
-      ROS_INFO("UNABLE TO SET PRIORITY OF PROCESS! (%i, %s)",errno,strerror(errno));
+      ROS_ERROR("UNABLE TO SET PRIORITY OF PROCESS! (%i, %s)",errno,strerror(errno));
     }
   }
 


### PR DESCRIPTION
Removing the "return false" command fixes the stopping of the node because of the 'permission denied' error. We have to investigate further why we don't have permissions when launching this node as a system daemon.